### PR TITLE
Added staging and marts models for sixsense pipeline

### DIFF
--- a/sixsense_pipeline/dbt_models/dbt_project.yml
+++ b/sixsense_pipeline/dbt_models/dbt_project.yml
@@ -1,0 +1,29 @@
+name: sixsense_dbt_project
+version: '1.0'
+
+config-version: 2
+
+profile: default
+
+model-paths: ["models"]
+analysis-paths: ["analyses"]
+test-paths: ["tests"]
+seed-paths: ["seeds"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"
+clean-targets:
+  - "target"
+  - "dbt_modules"
+
+models:
+  sixsense_dbt_project:
+    staging:
+      materialized: table
+      +database: dsv_ods
+      +schema: stg
+    marts:
+      materialized: view
+      +database: dsv_ods
+      +schema: mart

--- a/sixsense_pipeline/dbt_models/models/marts/fact_sixsense_intent.sql
+++ b/sixsense_pipeline/dbt_models/models/marts/fact_sixsense_intent.sql
@@ -1,0 +1,24 @@
+WITH 
+cte_source AS (
+
+    SELECT * 
+    FROM {{ ref('stg_sixsense_intent') }}
+
+)
+
+SELECT 
+    crm_account_id
+    ,crm_account_name
+    ,crm_account_country
+    ,crm_account_domain
+    ,keyword_researched
+    ,keyword_category
+    ,total
+    ,date_researched
+    ,sixsense_mid
+    ,sixsense_account_name
+    ,sixsense_account_country
+    ,sixsense_account_domain
+    ,load_date
+    ,dbt_loaded_by
+FROM cte_source

--- a/sixsense_pipeline/dbt_models/models/marts/fact_sixsense_predictive_leads.sql
+++ b/sixsense_pipeline/dbt_models/models/marts/fact_sixsense_predictive_leads.sql
@@ -1,0 +1,30 @@
+WITH 
+cte_source AS (
+
+    SELECT * 
+    FROM {{ ref('stg_sixsense_predictive_leads') }}
+
+)
+
+SELECT 
+    crm_lead_id
+    ,crm_account_name
+    ,crm_account_country
+    ,crm_account_domain
+    ,product_category
+    ,buying_stage
+    ,intent_score
+    ,profile_fit
+    ,profile_fit_score
+    ,contact_intent_grade
+    ,contact_intent_score
+    ,contact_profile_fit
+    ,contact_profile_fit_score
+    ,date
+    ,sixsense_mid
+    ,sixsense_account_name
+    ,sixsense_account_country
+    ,sixsense_account_domain
+    ,load_date
+    ,dbt_loaded_by
+FROM cte_source

--- a/sixsense_pipeline/dbt_models/models/staging/sixsense.yml
+++ b/sixsense_pipeline/dbt_models/models/staging/sixsense.yml
@@ -1,0 +1,14 @@
+version: 2
+
+models:
+  - name: stg_sixsense_intent
+    description: "Staging model for SixSense intent data."
+    columns:
+      - name: crm_account_id
+        description: "CRM account identifier."
+
+  - name: stg_sixsense_predictive_leads
+    description: "Staging model for SixSense predictive leads."
+    columns:
+      - name: crm_lead_id
+        description: "CRM lead identifier."

--- a/sixsense_pipeline/dbt_models/models/staging/src_sixsense.yml
+++ b/sixsense_pipeline/dbt_models/models/staging/src_sixsense.yml
@@ -1,0 +1,11 @@
+version: 2
+
+sources:
+  - name: sixsense
+    database: dsv_elt_ingestion
+    schema: six_sense
+    tables:
+      - name: raw_intent
+        description: "Raw intent data pulled from the SixSense SFTP and loaded via Databricks."
+      - name: raw_predictiveleads
+        description: "Raw predictive lead scoring data pulled from the SixSense SFTP and loaded via Databricks."

--- a/sixsense_pipeline/dbt_models/models/staging/stg_sixsense_intent.sql
+++ b/sixsense_pipeline/dbt_models/models/staging/stg_sixsense_intent.sql
@@ -1,0 +1,27 @@
+WITH 
+cte_source AS (
+    SELECT *
+    FROM {{ source('sixsense', 'raw_intent') }}
+),
+cte_transformed AS (
+    SELECT 
+        "CRM Account ID" AS crm_account_id
+        ,"CRM Account Name" AS crm_account_name
+        ,"CRM Account Country" AS crm_account_country
+        ,"CRM Account Domain" AS crm_account_domain
+        ,"Keyword Researched" AS keyword_researched
+        ,"Keyword Category" AS keyword_category
+        ,total
+        ,"Date Researched" AS date_researched
+        ,"6sense MID" AS sixsense_mid
+        ,"6sense Account Name" AS sixsense_account_name
+        ,"6sense Account Country" AS sixsense_account_country
+        ,"6sense Account Domain" AS sixsense_account_domain
+    FROM cte_source
+)
+
+SELECT 
+    *
+    ,CURRENT_TIMESTAMP() AS load_date
+    ,CURRENT_ROLE() AS dbt_loaded_by
+FROM cte_transformed

--- a/sixsense_pipeline/dbt_models/models/staging/stg_sixsense_predictive_leads.sql
+++ b/sixsense_pipeline/dbt_models/models/staging/stg_sixsense_predictive_leads.sql
@@ -1,0 +1,33 @@
+WITH 
+cte_source AS (
+    SELECT *
+    FROM {{ source('sixsense', 'raw_predictiveleads') }}
+),
+cte_transformed AS (
+    SELECT 
+        "CRM Lead ID" AS crm_lead_id
+        ,"CRM Account Name" AS crm_account_name
+        ,"CRM Account Country" AS crm_account_country
+        ,"CRM Account Domain" AS crm_account_domain
+        ,"Product Category" AS product_category
+        ,"Buying Stage" AS buying_stage
+        ,"Intent Score" AS intent_score
+        ,"Profile Fit" AS profile_fit
+        ,"Profile Fit Score" AS profile_fit_score
+        ,"Contact Intent Grade" AS contact_intent_grade
+        ,"Contact Intent Score" AS contact_intent_score
+        ,"Contact Profile Fit" AS contact_profile_fit
+        ,"Contact Profile Fit Score" AS contact_profile_fit_score
+        ,date
+        ,"6sense MID" AS sixsense_mid
+        ,"6sense Account Name" AS sixsense_account_name
+        ,"6sense Account Country" AS sixsense_account_country
+        ,"6sense Account Domain" AS sixsense_account_domain
+    FROM cte_source
+)
+
+SELECT 
+    *
+    ,CURRENT_TIMESTAMP() AS load_date
+    ,CURRENT_ROLE() AS dbt_loaded_by
+FROM cte_transformed

--- a/sixsense_pipeline/dbt_models/sixsense_dbt_models.md
+++ b/sixsense_pipeline/dbt_models/sixsense_dbt_models.md
@@ -1,0 +1,26 @@
+# dbt Models for SixSense Pipeline
+
+This folder contains the staging and mart layer dbt models used to transform and clean raw SixSense data ingested via Databricks into Snowflake.
+
+---
+
+## Staging Models
+
+- **stg_sixsense_intent.sql**: Cleans and renames columns from the raw `raw_intent` table.
+- **stg_sixsense_predictive_leads.sql**: Cleans and renames fields from the `raw_predictiveleads` table.
+
+---
+
+## Mart Models
+
+- **fact_sixsense_intent.sql**: Fact table that models intent activity for accounts.
+- **fact_sixsense_predictive_leads.sql**: Fact table representing predicted leads and their scores.
+
+---
+
+## Model Materialization
+
+- Staging models are materialized as **tables**
+- Mart models are materialized as **views**
+
+This is configured in `dbt_project.yml`.


### PR DESCRIPTION
- stg_sixsense_intent.sql: Cleans and renames columns from the raw `raw_intent` table.
- stg_sixsense_predictive_leads.sql: Cleans and renames fields from the `raw_predictiveleads` table.
- fact_sixsense_intent.sql: Fact table that models intent activity for accounts.
- fact_sixsense_predictive_leads.sql: Fact table representing predicted leads and their scores.