### PR TITLE
Added pendo api ingestion notebooks & utilities.

### DIFF
--- a/pendo_api_ingestion/notebooks/pendo_account.py
+++ b/pendo_api_ingestion/notebooks/pendo_account.py
@@ -1,0 +1,65 @@
+# Databricks notebook source
+# MAGIC %run pendo_api_ingestion/utilities/PendoApiUtil
+
+# COMMAND ----------
+
+# MAGIC %run general_utilities/EltUtil
+
+# COMMAND ----------
+
+try:
+    environment = dbutils.widgets.get("env") 
+except:
+    environment = 'dev'
+
+# COMMAND ----------
+
+ 
+az = AzureKv(environment)
+snow = SnowflakeUtil(env = environment, 
+                     user = az.get_secret('azure-snowflake-user'), 
+                     password = az.get_secret('azure-snowflake-password'), 
+                     database ='DSV_ELT_INGESTION' , 
+                     schema = 'PENDO', 
+                     warehouse = 'DSV_ELT_CP')
+
+# COMMAND ----------
+
+try:
+    pendo_subscription_type = dbutils.widgets.get("pendo_subscription")
+    integ_key = az.get_secret('pendo-customer-portal-api-integration-key') if pendo_subscription_type else None
+except:
+    pendo_subscription_type = None
+    integ_key = None
+
+# COMMAND ----------
+
+print(pendo_subscription_type)
+
+# COMMAND ----------
+
+pendo = PendoApiUtil('accounts', integ_key=integ_key)
+
+# COMMAND ----------
+
+extract_date = to_utc_timestamp(current_timestamp(),"UTC")
+res = pendo.send_request()
+
+# COMMAND ----------
+
+sdf = DatabricksUtil.df_jsonize_array_w_extract_date(res.json().get('results'), extract_date)
+
+# COMMAND ----------
+
+sdf = sdf.withColumn('load_date', to_utc_timestamp(current_timestamp(),"UTC"))
+
+# COMMAND ----------
+
+if pendo_subscription_type:
+    snow.write_df(sdf, 'pendo.raw_pendo_customer_portal_account', 'append')
+else:
+    snow.write_df(sdf, 'pendo.raw_pendo_account', 'append')
+
+# COMMAND ----------
+
+sdf.unpersist()

--- a/pendo_api_ingestion/notebooks/pendo_visitor.py
+++ b/pendo_api_ingestion/notebooks/pendo_visitor.py
@@ -1,0 +1,83 @@
+# Databricks notebook source
+# MAGIC %run ../Utilities/PendoApiUtil
+
+# COMMAND ----------
+
+# MAGIC %run ../../../Utilities/Elt/EltUtil
+
+# COMMAND ----------
+
+try:
+    environment = dbutils.widgets.get("env") 
+except:
+    environment = 'dev'
+
+# COMMAND ----------
+
+ 
+az = AzureKv(environment)
+snow = SnowflakeUtil(env = environment, 
+                     user = az.get_secret('azure-snowflake-user'), 
+                     password = az.get_secret('azure-snowflake-password'), 
+                     database ='DSV_ELT_INGESTION' , 
+                     schema = 'PENDO', 
+                     warehouse = 'DSV_ELT_CP')
+
+# COMMAND ----------
+
+try:
+    pendo_subscription_type = dbutils.widgets.get("pendo_subscription")
+    integ_key = az.get_secret('pendo-customer-portal-api-integration-key') if pendo_subscription_type else None
+except:
+    pendo_subscription_type = None
+    integ_key = None
+
+# COMMAND ----------
+
+try:
+    start_date = datetime.strptime(dbutils.widgets.get('start_date'), '%Y-%m-%dT%H:%M:%S%z')
+except:
+    start_date = datetime.now() - timedelta(days=1) # Yesterday in UTC/server-time.
+    print('Using default date.')
+
+print(f'{start_date=}')
+
+# COMMAND ----------
+
+start_date= start_date - timedelta(days=1)  #Move the start date to a date earlier to make sure all the data get imported due to different time zone.
+startdate = start_date.date()
+print(startdate)
+
+# COMMAND ----------
+
+print(pendo_subscription_type)
+
+# COMMAND ----------
+
+pendo = PendoApiUtil('visitor',start_date=start_date, integ_key=integ_key)
+
+# COMMAND ----------
+
+extract_date = to_utc_timestamp(current_timestamp(),"UTC")
+res = pendo.send_request()
+
+# COMMAND ----------
+
+if not res.json().get('results'):
+    dbutils.notebook.exit("no data")
+sdf = DatabricksUtil.df_jsonize_array_w_extract_date(res.json().get('results'), extract_date)
+
+# COMMAND ----------
+
+sdf = sdf.withColumn('load_date', to_utc_timestamp(current_timestamp(),"UTC"))
+
+# COMMAND ----------
+
+if pendo_subscription_type:
+    snow.write_df(sdf, 'pendo.raw_pendo_customer_portal_visitor', 'append')
+else:
+    snow.write_df(sdf, 'pendo.raw_pendo_visitor', 'append')
+
+# COMMAND ----------
+
+sdf.unpersist()

--- a/pendo_api_ingestion/pendo.md
+++ b/pendo_api_ingestion/pendo.md
@@ -1,0 +1,20 @@
+# Pendo API Ingestion
+
+This module ingests data from the Pendo API into Snowflake using Databricks notebooks.
+
+## Ingested Objects
+- `raw_pendo_account`
+- `raw_pendo_visitor`
+- `raw_pendo_customer_portal_account`
+- `raw_pendo_customer_portal_visitor`
+
+## Components
+- **PendoApiUtil**: Utility class to authenticate, build payloads, and send requests to Pendo's API.
+- **Databricks Notebooks**:
+  - `pendo_account`: Pulls account-level metadata.
+  - `pendo_visitor`: Pulls visitor data since the last extract timestamp.
+
+## Highlights
+- Uses `AzureKeyVault` for secure credential management.
+- Ingests data into Snowflake using `SnowflakeUtil`.
+- Supports both standard and customer portal subscriptions.

--- a/pendo_api_ingestion/utilities/PendoApiUtil.py
+++ b/pendo_api_ingestion/utilities/PendoApiUtil.py
@@ -1,0 +1,65 @@
+# Databricks notebook source
+# MAGIC %run ../Utilities/PendoApiUtil
+
+# COMMAND ----------
+
+# MAGIC %run ../../../Utilities/Elt/EltUtil
+
+# COMMAND ----------
+
+try:
+    environment = dbutils.widgets.get("env") 
+except:
+    environment = 'dev'
+
+# COMMAND ----------
+
+ 
+az = AzureKv(environment)
+snow = SnowflakeUtil(env = environment, 
+                     user = az.get_secret('azure-snowflake-user'), 
+                     password = az.get_secret('azure-snowflake-password'), 
+                     database ='DSV_ELT_INGESTION' , 
+                     schema = 'PENDO', 
+                     warehouse = 'DSV_ELT_CP')
+
+# COMMAND ----------
+
+try:
+    pendo_subscription_type = dbutils.widgets.get("pendo_subscription")
+    integ_key = az.get_secret('pendo-customer-portal-api-integration-key') if pendo_subscription_type else None
+except:
+    pendo_subscription_type = None
+    integ_key = None
+
+# COMMAND ----------
+
+print(pendo_subscription_type)
+
+# COMMAND ----------
+
+pendo = PendoApiUtil('accounts', integ_key=integ_key)
+
+# COMMAND ----------
+
+extract_date = to_utc_timestamp(current_timestamp(),"UTC")
+res = pendo.send_request()
+
+# COMMAND ----------
+
+sdf = DatabricksUtil.df_jsonize_array_w_extract_date(res.json().get('results'), extract_date)
+
+# COMMAND ----------
+
+sdf = sdf.withColumn('load_date', to_utc_timestamp(current_timestamp(),"UTC"))
+
+# COMMAND ----------
+
+if pendo_subscription_type:
+    snow.write_df(sdf, 'pendo.raw_pendo_customer_portal_account', 'append')
+else:
+    snow.write_df(sdf, 'pendo.raw_pendo_account', 'append')
+
+# COMMAND ----------
+
+sdf.unpersist()


### PR DESCRIPTION
- pendo_account.py – Ingests account metadata from Pendo’s API.
- pendo_visitor.py – Ingests visitor-level usage data from Pendo’s API, filtered by lastUpdated date.
- PendoApiUtil.py – Modular class for constructing and sending requests to Pendo's REST API. Supports multiple endpoints (accounts, visitors, features, events, etc.) with optional date filters and dynamic integration key support.
- Pulls integration keys from Azure KeyVault via AzureKv utility.
- Transforms API responses into Spark DataFrames and writes to Snowflake staging tables (pendo.raw_pendo_*), tagged with extract_date and load_date.